### PR TITLE
Fix `setup.cfg` for `flake8` `v6.x.x` release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,7 @@ license_files = LICENSE
 [flake8]
 max-line-length = 150
 ignore =
-    I100,  # Ordering of imports
-    I201,  # Newlines between imports
+# Ordering of imports
+    I100,
+# Newlines between imports
+    I201,


### PR DESCRIPTION
# *Fix `setup.cfg` for `flake8` `v6.x.x` release*

**What changed**: What parts of the code changed? What is the impact?
- Removal of inline comments in `setup.cfg`

**Why is this required?**: What is the context that led to this change? What is the value of it?
- The error is caused by inline comments used in `setup.cfg`
- https://flake8.pycqa.org/en/latest/release-notes/6.0.0.html#backwards-incompatible-changes
- https://flake8.pycqa.org/en/latest/user/configuration.html